### PR TITLE
Fix: make scrollbar appear only if it exceeds max height

### DIFF
--- a/flottform/forms/src/theme/defaultTheme.ts
+++ b/flottform/forms/src/theme/defaultTheme.ts
@@ -139,7 +139,7 @@ const addCss = () => {
 
 		details .details-container {
 			max-height: 12rem;
-  			overflow-y: scroll;
+  			overflow-y: auto;
 		}
 
 		details[open] summary {


### PR DESCRIPTION
**Checklist**

- [x] Resolves #31 
- [x] Labelled and assigned a reviewer

**Reviewer**

- [ ] I've checked out the code and tested it myself.

**Changes**

Scroll bar now appears only if we exceed the maximum height
