### PR TITLE
Remove automatic multiple attribute setting for inputField

### DIFF
--- a/flottform/forms/src/flottform-file-input-host.ts
+++ b/flottform/forms/src/flottform-file-input-host.ts
@@ -141,11 +141,6 @@ export class FlottformFileInputHost extends BaseInputHost<Listeners> {
 			return;
 		}
 
-		if (!this.inputField.multiple) {
-			this.logger.warn('Input field does not accept multiple files. Setting multiple to true.');
-			this.inputField.multiple = true;
-		}
-
 		const dt = new DataTransfer();
 
 		// Add existing files from the input field to the DataTransfer object to avoid loosing them.
@@ -153,6 +148,13 @@ export class FlottformFileInputHost extends BaseInputHost<Listeners> {
 			for (const file of Array.from(this.inputField.files)) {
 				dt.items.add(file);
 			}
+		}
+
+		if (!this.inputField.multiple) {
+			this.logger.warn(
+				"The host's input field only supports one file. Incoming files from the client will overwrite any existing file, and only the last file received will remain attached."
+			);
+			dt.items.clear();
 		}
 
 		const fileName = this.filesMetaData[fileIndex]?.name ?? 'no-name';


### PR DESCRIPTION
**Checklist**

- [x] Resolves #73 
- [x] Labelled and assigned a reviewer

**Reviewer**

- [x] I've checked out the code and tested it myself.

**Changes**
By adding this PR we should be able to handle all the possible scenarios based on whether the client and host input fields are set to allow multiple file uploads or just a single file.

---

### Scenarios and Suggested Approaches

1. **Single File Only on Both Client and Host (No `multiple` Attribute):**
   - **Scenario**: Both client and host input fields are configured to accept only one file (i.e., `multiple` attribute is not set). If the host already has a file attached and a new file arrives from the client, there’s a choice to either:
     - **Overwrite the existing file**.
     - **Reject the new file** since a file is already present.
   - **Chosen Approach**: **Overwrite the existing file.**
     - Since only one file can be attached at any given time, overwriting simplifies the process and keeps the input field up-to-date with the latest file received. 

2. **Client: Single File Only; Host: Multiple Files Allowed:**
   - **Scenario**: The client’s input field allows only one file, but the host’s input field can accept multiple files (has the `multiple` attribute). If the host already has files attached and a new file arrives from the client, there’s a choice to either:
     - **Append the new file** to the host’s existing files.
     - **Replace the host’s files** with the new file.
   - **Chosen Approach**: **Append the new file.**
     - Since the host is allowed to handle multiple files, appending keeps existing files intact, providing greater flexibility.

3. **Multiple Files Allowed on Both Client and Host (`multiple` Attribute Set for Both):**
   - **Scenario**: Both the client and the host allow multiple files. If the host already has files attached and new files arrive from the client, you can either:
     - **Add the new files** to the existing ones.
     - **Replace all files** on the host with the new ones.
   - **Chosen Approach**: **Append the new files.**
     - This preserves both the host’s and client’s files without unexpected loss, leveraging the host’s ability to handle multiple files. It also offers flexibility and avoids disrupting existing attachments.

4. **Client: Multiple Files Allowed; Host: Single File Only:**
   - **Scenario**: The client can send multiple files, but the host’s input field can only handle one file. If the host already has a file and multiple files are sent from the client, you can either:
     - **Replace the existing file** with the last file sent.
     - **Reject additional files** since the host only allows one.
   - **Chosen Approach**: **Overwrite with the last file received from the client.**
     - Given that the host allows only one file, overwriting with the most recent file provides a predictable outcome. If overwriting each time is too disruptive, you could log an alert or notification when files are replaced, but this approach generally keeps it straightforward.

