### PR TITLE
Clear outdated tables for browser extension

### DIFF
--- a/servers/chrome-extension/src/routes/+page.svelte
+++ b/servers/chrome-extension/src/routes/+page.svelte
@@ -233,6 +233,22 @@
 		});
 	};
 
+	const clearOutdatedTables = async () => {
+		// Wait for the current tab Id to be available!
+		const currentTabId = await getCurrentTabId();
+
+		chrome.scripting.executeScript({
+			target: { tabId: currentTabId! },
+			args: [currentTabId],
+			func: async (currentTabId) => {
+				// We have to find a way to add this listener only once & we have to handle single page applications since beforeunload doesn't work for those SPAs!
+				window.addEventListener('beforeunload', () => {
+					chrome.storage.local.set({ [`inputFields-${currentTabId}`]: [] });
+				});
+			}
+		});
+	};
+
 	onMount(async () => {
 		let [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
 		currentTabId = tab.id;
@@ -259,6 +275,8 @@
 				inputFields = result[`inputFields-${currentTabId}`];
 			}
 		});
+
+		clearOutdatedTables();
 	});
 </script>
 


### PR DESCRIPTION
**Checklist**

- [x] Resolves #84 
- [x] Labelled and assigned a reviewer

**Reviewer**

- [ ] I've checked out the code and tested it myself.

**Changes**

Now the unused tables will be deleted as soon as the user reloads the tab where Flottform was working, or leaves that tab entirely.

Limitations: 
1) For now the listeners that clean the tables are added multiple times inside the page context. We need to find a way to avoid that.
2) When dealing with single page applications, if we don't reload the tab not leave it but instead navigate to another page the array won't be deleted because the event `beforeunload` won't be fired! We also need to find a way to delete the array for this case.