### PR TITLE
Add a cleanup mechanism for old db entries

### DIFF
--- a/flottform/forms/src/flottform-channel-host.ts
+++ b/flottform/forms/src/flottform-channel-host.ts
@@ -19,6 +19,7 @@ export class FlottformChannelHost extends EventEmitter<FlottformEventMap> {
 	private pollTimeForIceInMs: number;
 	private logger: Logger;
 
+	private keepConnectionAliveIntervalId: NodeJS.Timeout | undefined;
 	private state: FlottformState | 'disconnected' = 'new';
 	private channelNumber: number = 0;
 	private openPeerConnection: RTCPeerConnection | null = null;
@@ -65,7 +66,7 @@ export class FlottformChannelHost extends EventEmitter<FlottformEventMap> {
 		}
 
 		try {
-			this.rtcConfiguration.iceServers = await this.fetchIceServers(this.baseApi);
+			this.rtcConfiguration.iceServers = await this.fetchIceServers();
 		} catch (error) {
 			// Use the default configuration as a fallback
 			this.logger.error(error);
@@ -108,8 +109,20 @@ export class FlottformChannelHost extends EventEmitter<FlottformEventMap> {
 			this.openPeerConnection = null;
 		}
 		this.changeState('disconnected');
+		// Stop heartbeat function.
+		clearInterval(this.keepConnectionAliveIntervalId);
 		// Cleanup old entries.
 		this.deleteEndpoint(this.baseApi, this.endpointId, this.hostKey);
+	};
+
+	private keepConnectionAlive = async (getEndpointInfoUrl: string) => {
+		this.keepConnectionAliveIntervalId = setInterval(
+			async () => {
+				// Make a GET request to refresh the connection
+				await retrieveEndpointInfo(getEndpointInfoUrl);
+			},
+			5 * 60 * 1000
+		);
 	};
 
 	private setupDataChannelListener = () => {
@@ -177,12 +190,18 @@ export class FlottformChannelHost extends EventEmitter<FlottformEventMap> {
 			this.logger.info(`onconnectionstatechange - ${this.openPeerConnection!.connectionState}`);
 			if (this.openPeerConnection!.connectionState === 'connected') {
 				this.stopPollingForConnection();
+				// Start the heartbeat process
+				this.keepConnectionAlive(getEndpointInfoUrl);
 			}
 			if (this.openPeerConnection!.connectionState === 'disconnected') {
 				this.startPollingForConnection(getEndpointInfoUrl);
+				// Stop the hearbeat process
+				clearInterval(this.keepConnectionAliveIntervalId);
 			}
 			if (this.openPeerConnection!.connectionState === 'failed') {
 				this.stopPollingForConnection();
+				// Stop the hearbeat process
+				clearInterval(this.keepConnectionAliveIntervalId);
 				this.changeState('error', { message: 'connection-failed' });
 			}
 		};
@@ -243,8 +262,8 @@ export class FlottformChannelHost extends EventEmitter<FlottformEventMap> {
 		return response.json();
 	};
 
-	private fetchIceServers = async (baseApi: string) => {
-		const response = await fetch(`${baseApi}/ice-server-credentials`, {
+	private fetchIceServers = async () => {
+		const response = await fetch(`${this.baseApi}/ice-server-credentials`, {
 			method: 'GET',
 			headers: {
 				Accept: 'application/json'

--- a/flottform/forms/src/flottform-text-input-host.ts
+++ b/flottform/forms/src/flottform-text-input-host.ts
@@ -67,6 +67,7 @@ export class FlottformTextInputHost extends BaseInputHost<Listeners> {
 		this.emit('receive');
 		// We suppose that the data received is small enough to be all included in 1 message
 		this.emit('done', e.data);
+		this.close();
 	};
 
 	private registerListeners = () => {

--- a/flottform/server/src/database.spec.ts
+++ b/flottform/server/src/database.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import { createFlottformDatabase } from './database';
 
 describe('Flottform database', () => {
@@ -177,9 +177,12 @@ describe('Flottform database', () => {
 	});
 
 	describe('startCleanup()', () => {
-		function sleep(ms: number) {
-			return new Promise((resolve) => setTimeout(resolve, ms));
-		}
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+		afterEach(() => {
+			vi.useRealTimers();
+		});
 
 		it('Should clean up stale entries after entryTTL', async () => {
 			const db = await createFlottformDatabase(1000, 500);
@@ -201,7 +204,7 @@ describe('Flottform database', () => {
 			});
 
 			// Sleep for enough time to trigger the first cleanup
-			await sleep(1100);
+			vi.advanceTimersByTime(1100);
 
 			// The endpoint should be cleaned by now
 			expect(async () => await db.getEndpoint({ endpointId })).rejects.toThrow(/endpoint/i);

--- a/flottform/server/src/database.spec.ts
+++ b/flottform/server/src/database.spec.ts
@@ -185,7 +185,10 @@ describe('Flottform database', () => {
 		});
 
 		it('Should clean up stale entries after entryTTL', async () => {
-			const db = await createFlottformDatabase(1000, 500);
+			const db = await createFlottformDatabase({
+				cleanupPeriod: 1000,
+				entryTimeToLive: 500
+			});
 			const conn = new RTCPeerConnection();
 			const offer = await conn.createOffer();
 			const { endpointId } = await db.createEndpoint({ session: offer });
@@ -211,7 +214,10 @@ describe('Flottform database', () => {
 		});
 
 		it("Shouldn't clean up entries before entryTTL is expired", async () => {
-			const db = await createFlottformDatabase(1000, 500);
+			const db = await createFlottformDatabase({
+				cleanupPeriod: 1000,
+				entryTimeToLive: 500
+			});
 			const conn = new RTCPeerConnection();
 			const offer = await conn.createOffer();
 			const { endpointId } = await db.createEndpoint({ session: offer });

--- a/flottform/server/src/database.spec.ts
+++ b/flottform/server/src/database.spec.ts
@@ -182,7 +182,7 @@ describe('Flottform database', () => {
 		}
 
 		it('Should clean up stale entries after entryTTL', async () => {
-			const db = await createFlottformDatabase(100, 50);
+			const db = await createFlottformDatabase(1000, 500);
 			const conn = new RTCPeerConnection();
 			const offer = await conn.createOffer();
 			const { endpointId } = await db.createEndpoint({ session: offer });
@@ -201,14 +201,14 @@ describe('Flottform database', () => {
 			});
 
 			// Sleep for enough time to trigger the first cleanup
-			await sleep(110);
+			await sleep(1100);
 
 			// The endpoint should be cleaned by now
 			expect(async () => await db.getEndpoint({ endpointId })).rejects.toThrow(/endpoint/i);
 		});
 
 		it("Shouldn't clean up entries before entryTTL is expired", async () => {
-			const db = await createFlottformDatabase(100, 50);
+			const db = await createFlottformDatabase(1000, 500);
 			const conn = new RTCPeerConnection();
 			const offer = await conn.createOffer();
 			const { endpointId } = await db.createEndpoint({ session: offer });

--- a/flottform/server/src/database.spec.ts
+++ b/flottform/server/src/database.spec.ts
@@ -168,7 +168,9 @@ describe('Flottform database', () => {
 						session: answer,
 						iceCandidates: []
 					})
-			).rejects.toThrow(/peerkey/i);
+			).rejects.toThrow(
+				/clientKey is wrong: Another peer is already connected and you cannot change this info without the correct key anymore. If you lost your key, initiate a new Flottform connection./i
+			);
 			const infoAfter = await db.getEndpoint({ endpointId });
 			expect(infoBefore).toStrictEqual(infoAfter);
 		});

--- a/flottform/server/src/database.spec.ts
+++ b/flottform/server/src/database.spec.ts
@@ -33,7 +33,8 @@ describe('Flottform database', () => {
 					await db.putHostInfo({
 						endpointId,
 						hostKey: 'clearly-wrong',
-						iceCandidates: []
+						iceCandidates: [],
+						session: offer
 					})
 			).rejects.toThrow(/hostkey/i);
 		});
@@ -202,8 +203,7 @@ describe('Flottform database', () => {
 				endpointId,
 				clientKey,
 				session: answer,
-				iceCandidates: [],
-				lastUpdate: Date.now()
+				iceCandidates: []
 			});
 
 			// Sleep for enough time to trigger the first cleanup
@@ -231,8 +231,7 @@ describe('Flottform database', () => {
 				endpointId,
 				clientKey,
 				session: answer,
-				iceCandidates: [],
-				lastUpdate: Date.now()
+				iceCandidates: []
 			});
 
 			// The endpoint shouldn't be cleaned by now

--- a/flottform/server/src/database.ts
+++ b/flottform/server/src/database.ts
@@ -92,12 +92,14 @@ class FlottformDatabase {
 		endpointId,
 		hostKey,
 		session,
-		iceCandidates
+		iceCandidates,
+		lastUpdate = Date.now()
 	}: {
 		endpointId: EndpointId;
 		hostKey: HostKey;
 		session: RTCSessionDescriptionInit;
 		iceCandidates: RTCIceCandidateInit[];
+		lastUpdate?: number;
 	}): Promise<SafeEndpointInfo> {
 		const existingSession = this.map.get(endpointId);
 		if (!existingSession) {
@@ -110,7 +112,7 @@ class FlottformDatabase {
 		const newInfo = {
 			...existingSession,
 			hostInfo: { ...existingSession.hostInfo, session, iceCandidates },
-			lastUpdate: Date.now()
+			lastUpdate
 		};
 		this.map.set(endpointId, newInfo);
 
@@ -123,12 +125,14 @@ class FlottformDatabase {
 		endpointId,
 		clientKey,
 		session,
-		iceCandidates
+		iceCandidates,
+		lastUpdate = Date.now()
 	}: {
 		endpointId: EndpointId;
 		clientKey: ClientKey;
 		session: RTCSessionDescriptionInit;
 		iceCandidates: RTCIceCandidateInit[];
+		lastUpdate?: number;
 	}): Promise<Required<SafeEndpointInfo>> {
 		const existingSession = this.map.get(endpointId);
 		if (!existingSession) {
@@ -144,7 +148,7 @@ class FlottformDatabase {
 			...existingSession,
 			clientKey,
 			clientInfo: { session, iceCandidates },
-			lastUpdate: Date.now()
+			lastUpdate
 		};
 		this.map.set(endpointId, newInfo);
 
@@ -169,8 +173,11 @@ class FlottformDatabase {
 	}
 }
 
-export async function createFlottformDatabase(): Promise<FlottformDatabase> {
-	return new FlottformDatabase();
+export async function createFlottformDatabase(
+	cleanupPeriod = 30 * 60 * 1000,
+	entryTTL = 25 * 60 * 1000
+): Promise<FlottformDatabase> {
+	return new FlottformDatabase(cleanupPeriod, entryTTL);
 }
 
 export type { FlottformDatabase };

--- a/flottform/server/src/database.ts
+++ b/flottform/server/src/database.ts
@@ -27,10 +27,12 @@ function createRandomEndpointId(): string {
 class FlottformDatabase {
 	private map = new Map<EndpointId, EndpointInfo>();
 	private cleanupIntervalId: NodeJS.Timeout | null = null;
-	private cleanupPeriod = 30 * 60 * 1000; // (30 minutes)
-	private entryTTL = 25 * 60 * 1000; // Time-to-Live for each entry (25 minutes)
+	private cleanupPeriod;
+	private entryTTL; // Time-to-Live for each entry
 
-	constructor() {
+	constructor(cleanupPeriod = 30 * 60 * 1000, entryTTL = 25 * 60 * 1000) {
+		this.cleanupPeriod = cleanupPeriod;
+		this.entryTTL = entryTTL;
 		this.startCleanup();
 	}
 

--- a/flottform/server/src/database.ts
+++ b/flottform/server/src/database.ts
@@ -33,9 +33,15 @@ class FlottformDatabase {
 	private cleanupPeriod: number;
 	private entryTimeToLive: number;
 
-	constructor(cleanupPeriod = DEFAULT_CLEANUP_PERIOD, entryTTL = DEFAULT_ENTRY_TIME_TO_LIVE_IN_MS) {
+	constructor({
+		cleanupPeriod = DEFAULT_CLEANUP_PERIOD,
+		entryTimeToLive = DEFAULT_ENTRY_TIME_TO_LIVE_IN_MS
+	}: {
+		cleanupPeriod?: number;
+		entryTimeToLive?: number;
+	} = {}) {
 		this.cleanupPeriod = cleanupPeriod;
-		this.entryTimeToLive = entryTTL;
+		this.entryTimeToLive = entryTimeToLive;
 		this.startCleanup();
 	}
 
@@ -51,7 +57,6 @@ class FlottformDatabase {
 				const lastUpdated = endpointInfo.lastUpdate;
 				if (now - lastUpdated > this.entryTimeToLive) {
 					this.map.delete(endpointId);
-					console.log(`Cleaned up stale entry: ${endpointId}`);
 				}
 			}
 		}
@@ -181,11 +186,14 @@ class FlottformDatabase {
 	}
 }
 
-export async function createFlottformDatabase(
+export async function createFlottformDatabase({
 	cleanupPeriod = DEFAULT_CLEANUP_PERIOD,
-	entryTTL = DEFAULT_ENTRY_TIME_TO_LIVE_IN_MS
-): Promise<FlottformDatabase> {
-	return new FlottformDatabase(cleanupPeriod, entryTTL);
+	entryTimeToLive = DEFAULT_ENTRY_TIME_TO_LIVE_IN_MS
+}: {
+	cleanupPeriod?: number;
+	entryTimeToLive?: number;
+} = {}): Promise<FlottformDatabase> {
+	return new FlottformDatabase({ cleanupPeriod, entryTimeToLive });
 }
 
 export type { FlottformDatabase };

--- a/flottform/server/src/database.ts
+++ b/flottform/server/src/database.ts
@@ -15,7 +15,7 @@ type EndpointInfo = {
 	};
 	lastUpdate: number;
 };
-type SafeEndpointInfo = Omit<EndpointInfo, 'hostKey' | 'clientKey'>;
+type SafeEndpointInfo = Omit<EndpointInfo, 'hostKey' | 'clientKey' | 'lastUpdate'>;
 
 const DEFAULT_CLEANUP_PERIOD = 30 * 60 * 1000;
 const DEFAULT_ENTRY_TIME_TO_LIVE_IN_MS = 25 * 60 * 1000;
@@ -96,7 +96,7 @@ class FlottformDatabase {
 			throw Error('Endpoint not found');
 		}
 		entry.lastUpdate = Date.now();
-		const { hostKey: _ignore1, clientKey: _ignore2, ...endpoint } = entry;
+		const { hostKey: _ignore1, clientKey: _ignore2, lastUpdate: _ignore3, ...endpoint } = entry;
 
 		return endpoint;
 	}
@@ -105,14 +105,12 @@ class FlottformDatabase {
 		endpointId,
 		hostKey,
 		session,
-		iceCandidates,
-		lastUpdate = Date.now()
+		iceCandidates
 	}: {
 		endpointId: EndpointId;
 		hostKey: HostKey;
 		session: RTCSessionDescriptionInit;
 		iceCandidates: RTCIceCandidateInit[];
-		lastUpdate?: number;
 	}): Promise<SafeEndpointInfo> {
 		const existingSession = this.map.get(endpointId);
 		if (!existingSession) {
@@ -125,11 +123,16 @@ class FlottformDatabase {
 		const newInfo = {
 			...existingSession,
 			hostInfo: { ...existingSession.hostInfo, session, iceCandidates },
-			lastUpdate
+			lastUpdate: Date.now()
 		};
 		this.map.set(endpointId, newInfo);
 
-		const { hostKey: _ignore1, clientKey: _ignore2, ...newEndpoint } = newInfo;
+		const {
+			hostKey: _ignore1,
+			clientKey: _ignore2,
+			lastUpdate: _ignore3,
+			...newEndpoint
+		} = newInfo;
 
 		return newEndpoint;
 	}
@@ -138,14 +141,12 @@ class FlottformDatabase {
 		endpointId,
 		clientKey,
 		session,
-		iceCandidates,
-		lastUpdate = Date.now()
+		iceCandidates
 	}: {
 		endpointId: EndpointId;
 		clientKey: ClientKey;
 		session: RTCSessionDescriptionInit;
 		iceCandidates: RTCIceCandidateInit[];
-		lastUpdate?: number;
 	}): Promise<Required<SafeEndpointInfo>> {
 		const existingSession = this.map.get(endpointId);
 		if (!existingSession) {
@@ -161,11 +162,16 @@ class FlottformDatabase {
 			...existingSession,
 			clientKey,
 			clientInfo: { session, iceCandidates },
-			lastUpdate
+			lastUpdate: Date.now()
 		};
 		this.map.set(endpointId, newInfo);
 
-		const { hostKey: _ignore1, clientKey: _ignore2, ...newEndpoint } = newInfo;
+		const {
+			hostKey: _ignore1,
+			clientKey: _ignore2,
+			lastUpdate: _ignore3,
+			...newEndpoint
+		} = newInfo;
 
 		return newEndpoint;
 	}


### PR DESCRIPTION
**Checklist**

- [ ] Resolves #103 
- [ ] Labelled and assigned a reviewer

**Reviewer**

- [ ] I've checked out the code and tested it myself.

**Changes**

+ Call the method `close` (in the classes: `FlottformFileInputHost` and `FlottformTextInputHost`) whenever the file/text transfer is done so that the `close` method in `FlottformChannelHost` triggers a `DELETE request` to remove the entry from the signaling server DB.
+ Implement cleanup mechanism for stale database entries on a regular basis (for now every 30 minutes + an entry is considered stale if it was not updated for more than 25 minutes)
